### PR TITLE
fix(circleci): downgrading the node orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  node: circleci/node@2.0.3
+  node: circleci/node@1.1.6
 jobs:
   build-and-test:
     executor:


### PR DESCRIPTION
## description

downgrading the circleci node orb version in order to fix the ci error

## changelog

**new**

- 

**changed**

- circleci/node@x.y.z from 2.0.6. to 1.1.6
